### PR TITLE
Update `git push` command in git-datasets.md

### DIFF
--- a/data/git-datasets.md
+++ b/data/git-datasets.md
@@ -156,7 +156,7 @@ Once you have access you can:
 ```
 git annex copy --to=origin
 git annex sync --no-content --only-annex
-git push
+git push --set-upstream origin xy/some-topic
 ```
 
 Finally, ask one of that dataset's reviewers to [look at your pull request](#Reviewing-Pull-Requests) by opening an issue on [neuropoly/data-management](https://github.com/neuropoly/data-management).


### PR DESCRIPTION
When uploading a new branch to git-annex, I have to run:

```
git push --set-upstream origin xy/some-topic
```

instead of 

```
git push
```

I updated this command in [data/git-datasets.md](https://github.com/neuropoly/intranet.neuro.polymtl.ca/compare/master...jv/update_git-datasets.md?quick_pull=1#diff-286854a6f974370ea66f9a14845277355e352500392d9061a1b5bd7146db6532)