### PR TITLE
Centralize derivatives conventions for BIDS datasets

### DIFF
--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -261,7 +261,62 @@ If you choose to also fill in BIDS's optional [CHANGES](https://bids-specificati
 
 ## Derivatives Structure
 
-The [`derivatives`](https://bids-specification.readthedocs.io/en/stable/05-derivatives/01-introduction.html) are files generated from the top-level dataset such as segmentations or labels.
+This is a folder at the root of the dataset, which includes derivatives files generated from the top-level dataset such as segmentations or labeling.
+According to BIDS, these data should go under [`derivatives/`](https://bids-specification.readthedocs.io/en/stable/05-derivatives/01-introduction.html) folder, and follow the same folder logic as the `sub-*` data. 
+Example:
+
+```
+...
+...
+├── sub-XXX
+│   └── anat
+│       └──sub-XXX_T1w.nii.gz
+...
+...
+└── derivatives
+    ├── dataset_description.json
+    └── manual_labels
+        ├── sub-XXX
+        │   ├── anat
+        │   │   ├──sub-XXX_T1w_label-SC_seg.nii.gz
+        │   │   ├──sub-XXX_T1w_label-SC_propseg.nii.gz
+        │   │   ├──sub-XXX_T1w_label-SC_mask.nii.gz
+        │   │   ├──sub-XXX_T1w_label-GM_seg.nii.gz
+        │   │   ├──sub-XXX_T1w_label-WM_seg.nii.gz
+        │   │   ├──sub-XXX_T1w_label-centerline.nii.gz
+        │   │   ├──sub-XXX_T1w_label-disc.nii.gz
+        │   │   ├──sub-XXX_T1w_label-lesion.nii.gz
+        │   │   ├──sub-XXX_T1w_label-compression.nii.gz
+        ...
+        ...
+```
+
+The convention for suffix is the following:
+
+- `label-<region>_seg.nii.gz`: binary segmentation of the region `<region>`
+- `label-<region>_probseg.nii.gz`: probabilistic segmentation of the region `<region>`
+- `label-<region>_mask.nii.gz`: binary mask of the region `<region>`
+- `label-<region>_probmask.nii.gz`: probabilistic mask of the region `<region>`
+- `label-centerline.nii.gz`: binary spinal cord centerline
+- `label-disc.nii.gz`: intervertebral disc labels, see [here](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling) for details
+- `label-lesion.nii.gz`: lesion (for example in multiple sclerosis), see [here](https://github.com/ivadomed/model_seg_sci#data) for details
+- `label-compression.nii.gz`: spinal cord compression labels, see [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3984#issuecomment-1373008539) for details
+
+```
+Fields:
+- region = {SC, GM, WM, CSF, brainstem, tumor, edema, cavity, axon, myelin}
+```
+
+If you have multiple derivatives, you can create a folder for each of them, and then follow the same logic as above. For example:
+
+```
+...
+...
+└── derivatives
+    ├── dataset_description.json
+    ├── manual_labels
+    └── manual_labels_softseg
+```
 
 Convention for derivatives JSON metadata:
 

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -296,7 +296,7 @@ Example:
 The convention for suffix is the following:
 
 - `label-<region>_seg.nii.gz`: binary segmentation of the region `<region>`
-- `label-<region>_probseg.nii.gz`: probabilistic segmentation of the region `<region>`
+- `label-<region>_probseg.nii.gz`: probabilistic (soft) segmentation (i.e., values can lie between 0 and 1) of the region `<region>`
 - `label-<region>_mask.nii.gz`: binary mask of the region `<region>`, for example, cylinder mask with diameter of 35mm centered at the center of the spinal cord
 - `label-<region>_probmask.nii.gz`: probabilistic mask of the region `<region>`
 - `label-centerline.nii.gz`: binary spinal cord centerline

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -272,7 +272,7 @@ Convention for derivatives JSON metadata:
 }
 ```
 
-NOTE: "Date" is optional. We usually include it when running the manual correction via python scripts.
+NOTE: "Date" is optional. We usually include it when running the manual correction via [python scripts](https://github.com/spinalcordtoolbox/manual-correction).
 
 ```{warning}
 The `derivatives` must include its own `dataset_description.json` file (with `"DatasetType": "derivative"`).

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -59,7 +59,11 @@ If you need to differentiate between sequences acquired with different orientati
 ```
 
 ```{note}
-If you need to differentiate between different magnetization transfer (MT) seqeunces, use the `acq-MTon` or `acq-MToff` tag. For example, `sub-001_acq-MTon_T1w.nii.gz`.
+If you need to differentiate between different magnetization transfer (MT) seqeunces, use the [`flip-<index>_mt-<on|off>`](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data) tag. For example, `sub-001_flip-1_mt-on_MTS.nii.gz`, `sub-001_flip-1_mt-off_MTS.nii.gz` or `sub-001_flip-2_mt-off_MTS.nii.gz`.
+Here is a conversion table between our old convention and the new one:
+acq-MTon_MTS → flip-1_mt-on_MTS
+acq-MToff_MTS → flip-1_mt-off_MTS
+acq-T1w_MTS → flip-2_mt-off_MTS
 ```
 
 ```{note}

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -300,7 +300,7 @@ Example:
         ...
 ```
 
-The convention for suffix is the following:
+The convention for suffix is inspired from the [BIDS convention](https://bids-specification.readthedocs.io/en/stable/05-derivatives/03-imaging.html#imaging-data-types) and is the following::
 
 - `label-<region>_seg.nii.gz`: binary segmentation of the region `<region>`
 - `label-<region>_probseg.nii.gz`: probabilistic (soft) segmentation (i.e., values can lie between 0 and 1) of the region `<region>`

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -295,7 +295,7 @@ The convention for suffix is the following:
 
 - `label-<region>_seg.nii.gz`: binary segmentation of the region `<region>`
 - `label-<region>_probseg.nii.gz`: probabilistic segmentation of the region `<region>`
-- `label-<region>_mask.nii.gz`: binary mask of the region `<region>`
+- `label-<region>_mask.nii.gz`: binary mask of the region `<region>`, for example, cylinder mask with diameter of 35mm centered at the center of the spinal cord
 - `label-<region>_probmask.nii.gz`: probabilistic mask of the region `<region>`
 - `label-centerline.nii.gz`: binary spinal cord centerline
 - `label-disc.nii.gz`: intervertebral disc labels, see [here](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling) for details

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -52,6 +52,7 @@ Many kinds of data have a place specified for them by BIDS. See [file naming con
 
 ```{note}
 If you need to differentiate spinal cord images from the brain, use the `acq-cspine` tag. For example, `sub-001_acq-cspine_T1w.nii.gz`.
+Note: We opted for `acq-cspine` tag (see [BIDS template](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data)) because `bp-cspine` is not currently supported by the BIDS convention (see [BEP25](https://docs.google.com/document/d/1chZv7vAPE-ebPDxMktfI9i1OkLNR2FELIfpVYsaZPr4/edit) BIDS extension proposal).
 ```
 
 ```{note}

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -303,7 +303,7 @@ The convention for suffix is the following:
 - `label-disc.nii.gz`: voxels located at the posterior tip of each intervertebral disc, with values corresponding to [SCT convention](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling)
 - `label-pmj.nii.gz`: a single voxel with value of `50` corresponding to the pontomedullary junction (PMJ), see [SCT convention](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling) for details
 - `label-compression.nii.gz`: voxel(s) with value of `1` located at the posterior tip of each intervertebral disc corresponding to the spinal cord compression(s), see [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3984#issuecomment-1373008539) for details
-- `label-lesion.nii.gz`: lesion (for example in multiple sclerosis), see [here](https://github.com/ivadomed/model_seg_sci#data) for details
+- `label-<region>_lesion.nii.gz`: lesion (for example in multiple sclerosis), see [here](https://github.com/ivadomed/model_seg_sci#data) for details
 
 ```
 Fields:

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -59,7 +59,7 @@ If you need to differentiate between sequences acquired with different orientati
 ```
 
 ```{note}
-If you need to differentiate between different magnetization transfer (MT) seqeunces, use the [`flip-<index>_mt-<on|off>`](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data) tag. For example, `sub-001_flip-1_mt-on_MTS.nii.gz`, `sub-001_flip-1_mt-off_MTS.nii.gz` or `sub-001_flip-2_mt-off_MTS.nii.gz`.
+If you need to differentiate between different magnetization transfer (MT) sequences, use the [`flip-<index>_mt-<on|off>`](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data) tag. For example, `sub-001_flip-1_mt-on_MTS.nii.gz`, `sub-001_flip-1_mt-off_MTS.nii.gz` or `sub-001_flip-2_mt-off_MTS.nii.gz`.
 Here is a conversion table between our old convention and the new one:
 acq-MTon_MTS → flip-1_mt-on_MTS
 acq-MToff_MTS → flip-1_mt-off_MTS

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -265,6 +265,13 @@ If you choose to also fill in BIDS's optional [CHANGES](https://bids-specificati
 
 This is a folder at the root of the dataset, which includes derivatives files generated from the top-level dataset such as segmentations or labeling.
 According to BIDS, these data should go under [`derivatives/`](https://bids-specification.readthedocs.io/en/stable/05-derivatives/01-introduction.html) folder, and follow the same folder logic as the `sub-*` data. 
+
+```{warning}
+If derivatives files were generated from preprocessed data (e.g., after reorientation and resampling), describe the 
+preprocessing steps in README.md file. Also, include the link (pointing to fixed GitHub version) to the pipeline to the 
+README.md file.
+```
+
 Example:
 
 ```

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -302,10 +302,10 @@ The convention for suffix is the following:
 - `label-<region>_mask.nii.gz`: binary mask of the region `<region>`, for example, cylinder mask with diameter of 35mm centered at the center of the spinal cord
 - `label-<region>_probmask.nii.gz`: probabilistic mask of the region `<region>`
 - `label-centerline.nii.gz`: binary spinal cord centerline
-- `label-disc.nii.gz`: intervertebral disc labels, see [here](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling) for details
-- `label-pmj.nii.gz`: pontomedullary junction (PMJ) label, see [here](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling) for details
+- `label-disc.nii.gz`: voxels located at the posterior tip of each intervertebral disc, with values corresponding to [SCT convention](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling)
+- `label-pmj.nii.gz`: a single voxel with value of `50` corresponding to the pontomedullary junction (PMJ), see [SCT convention](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling) for details
+- `label-compression.nii.gz`: voxel(s) with value of `1` located at the posterior tip of each intervertebral disc corresponding to the spinal cord compression(s), see [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3984#issuecomment-1373008539) for details
 - `label-lesion.nii.gz`: lesion (for example in multiple sclerosis), see [here](https://github.com/ivadomed/model_seg_sci#data) for details
-- `label-compression.nii.gz`: spinal cord compression labels, see [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3984#issuecomment-1373008539) for details
 
 ```
 Fields:

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -50,8 +50,20 @@ sub-001
 
 Many kinds of data have a place specified for them by BIDS. See [file naming conventions](https://bids-specification.readthedocs.io/en/stable/02-common-principles.html#filesystem-structure) and the [MRI](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html) and [Microscopy](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html) extensions for full details.
 
-```{warning}
-TODO: describe neuropoly-specific BIDS entities, like bp-cspine or acq-MTon
+```{note}
+If you need to differentiate spinal cord images from the brain, use the `acq-cspine` tag. For example, `sub-001_acq-cspine_T1w.nii.gz`.
+```
+
+```{note}
+If you need to differentiate between sequences acquired with different orientations, use the `acq-axial` or `acq-sagittal` tag. For example, `sub-001_acq-axial_T1w.nii.gz`.
+```
+
+```{note}
+If you need to differentiate between different magnetization transfer (MT) seqeunces, use the `acq-MTon` or `acq-MToff` tag. For example, `sub-001_acq-MTon_T1w.nii.gz`.
+```
+
+```{note}
+If you to combine several above mentioned tags, use camelCase. For example, `sub-001_acq-cspineSagittal_T1w.nii.gz`.
 ```
 
 ## BIDS template

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -314,7 +314,7 @@ The convention for suffix is the following:
 
 ```
 Fields:
-- region = {SC, GM, WM, CSF, brainstem, tumor, edema, cavity, axon, myelin}
+- region = {SC, GM, WM, CSF, brain, brainstem, tumor, edema, cavity, axon, myelin}
 ```
 
 If you have multiple derivatives, you can create a folder for each of them, and then follow the same logic as above. For example:

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -299,6 +299,7 @@ The convention for suffix is the following:
 - `label-<region>_probmask.nii.gz`: probabilistic mask of the region `<region>`
 - `label-centerline.nii.gz`: binary spinal cord centerline
 - `label-disc.nii.gz`: intervertebral disc labels, see [here](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling) for details
+- `label-pmj.nii.gz`: pontomedullary junction (PMJ) label, see [here](https://spinalcordtoolbox.com/user_section/tutorials/registration-to-template/vertebral-labeling/labeling-conventions.html?highlight=labeling) for details
 - `label-lesion.nii.gz`: lesion (for example in multiple sclerosis), see [here](https://github.com/ivadomed/model_seg_sci#data) for details
 - `label-compression.nii.gz`: spinal cord compression labels, see [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/3984#issuecomment-1373008539) for details
 

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -50,26 +50,23 @@ sub-001
 
 Many kinds of data have a place specified for them by BIDS. See [file naming conventions](https://bids-specification.readthedocs.io/en/stable/02-common-principles.html#filesystem-structure) and the [MRI](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html) and [Microscopy](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html) extensions for full details.
 
-```{note}
-If you need to differentiate spinal cord images from the brain, use the `acq-cspine` tag. For example, `sub-001_acq-cspine_T1w.nii.gz`.
+ℹ️ If you need to differentiate spinal cord images from the brain, use the `acq-cspine` tag. For example, `sub-001_acq-cspine_T1w.nii.gz`.
+
 Note: We opted for `acq-cspine` tag (see [BIDS template](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data)) because `bp-cspine` is not currently supported by the BIDS convention (see [BEP25](https://docs.google.com/document/d/1chZv7vAPE-ebPDxMktfI9i1OkLNR2FELIfpVYsaZPr4/edit) BIDS extension proposal).
-```
 
-```{note}
-If you need to differentiate between sequences acquired with different orientations, use the `acq-axial` or `acq-sagittal` tag. For example, `sub-001_acq-axial_T1w.nii.gz`.
-```
+ℹ️ If you need to differentiate between sequences acquired with different orientations, use the `acq-axial` or `acq-sagittal` tag. For example, `sub-001_acq-axial_T1w.nii.gz`.
 
-```{note}
-If you need to differentiate between different magnetization transfer (MT) sequences, use the [`flip-<index>_mt-<on|off>`](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data) tag. For example, `sub-001_flip-1_mt-on_MTS.nii.gz`, `sub-001_flip-1_mt-off_MTS.nii.gz` or `sub-001_flip-2_mt-off_MTS.nii.gz`.
+ℹ️ If you need to differentiate between different magnetization transfer (MT) sequences, use the [`flip-<index>_mt-<on|off>`](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data) tag. For example, `sub-001_flip-1_mt-on_MTS.nii.gz`, `sub-001_flip-1_mt-off_MTS.nii.gz` or `sub-001_flip-2_mt-off_MTS.nii.gz`.
+
 Here is a conversion table between our old convention and the new one:
+```
 acq-MTon_MTS → flip-1_mt-on_MTS
 acq-MToff_MTS → flip-1_mt-off_MTS
 acq-T1w_MTS → flip-2_mt-off_MTS
 ```
 
-```{note}
-If you to combine several above mentioned tags, use camelCase. For example, `sub-001_acq-cspineSagittal_T1w.nii.gz`.
-```
+ℹ️ If you to combine several above mentioned tags, use camelCase. For example, `sub-001_acq-cspineSagittal_T1w.nii.gz`.
+
 
 ## BIDS template
 

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -50,23 +50,27 @@ sub-001
 
 Many kinds of data have a place specified for them by BIDS. See [file naming conventions](https://bids-specification.readthedocs.io/en/stable/02-common-principles.html#filesystem-structure) and the [MRI](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html) and [Microscopy](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/10-microscopy.html) extensions for full details.
 
-ℹ️ If you need to differentiate spinal cord images from the brain, use the `acq-cspine` tag. For example, `sub-001_acq-cspine_T1w.nii.gz`.
+```{note}
+If you need to differentiate spinal cord images from the brain, use the `acq-cspine` tag. For example, `sub-001_acq-cspine_T1w.nii.gz`.
 
-Note: We opted for `acq-cspine` tag (see [BIDS template](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data)) because `bp-cspine` is not currently supported by the BIDS convention (see [BEP25](https://docs.google.com/document/d/1chZv7vAPE-ebPDxMktfI9i1OkLNR2FELIfpVYsaZPr4/edit) BIDS extension proposal).
+ℹ️ We opted for `acq-cspine` tag (see [BIDS template](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data)) because `bp-cspine` is not currently supported by the BIDS convention (see [BEP25](https://docs.google.com/document/d/1chZv7vAPE-ebPDxMktfI9i1OkLNR2FELIfpVYsaZPr4/edit) BIDS extension proposal).
+```
 
-ℹ️ If you need to differentiate between sequences acquired with different orientations, use the `acq-axial` or `acq-sagittal` tag. For example, `sub-001_acq-axial_T1w.nii.gz`.
+```{note}
+If you need to differentiate between sequences acquired with different orientations, use the `acq-axial` or `acq-sagittal` tag. For example, `sub-001_acq-axial_T1w.nii.gz`.
+```
 
-ℹ️ If you need to differentiate between different magnetization transfer (MT) sequences, use the [`flip-<index>_mt-<on|off>`](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data) tag. For example, `sub-001_flip-1_mt-on_MTS.nii.gz`, `sub-001_flip-1_mt-off_MTS.nii.gz` or `sub-001_flip-2_mt-off_MTS.nii.gz`.
-
-Here is a conversion table between our old convention and the new one:
+```{note}
+If you need to differentiate between different magnetization transfer (MT) sequences, use the [`flip-<index>_mt-<on|off>`](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data) tag. For example, `sub-001_flip-1_mt-on_MTS.nii.gz`, `sub-001_flip-1_mt-off_MTS.nii.gz` or `sub-001_flip-2_mt-off_MTS.nii.gz`.
 ```
 acq-MTon_MTS → flip-1_mt-on_MTS
 acq-MToff_MTS → flip-1_mt-off_MTS
 acq-T1w_MTS → flip-2_mt-off_MTS
 ```
 
-ℹ️ If you to combine several above mentioned tags, use camelCase. For example, `sub-001_acq-cspineSagittal_T1w.nii.gz`.
-
+```{note}
+ If you to combine several above mentioned tags, use camelCase. For example, `sub-001_acq-cspineSagittal_T1w.nii.gz`.
+```
 
 ## BIDS template
 
@@ -337,7 +341,9 @@ Convention for derivatives JSON metadata:
 }
 ```
 
-NOTE: "Date" is optional. We usually include it when running the manual correction via [python scripts](https://github.com/spinalcordtoolbox/manual-correction).
+```{note}
+`"Date"` is optional. We usually include it when running the manual correction via [python scripts](https://github.com/spinalcordtoolbox/manual-correction).
+```
 
 ```{warning}
 The `derivatives` must include its own `dataset_description.json` file (with `"DatasetType": "derivative"`).

--- a/data/dataset-curation.md
+++ b/data/dataset-curation.md
@@ -63,10 +63,6 @@ If you need to differentiate between sequences acquired with different orientati
 ```{note}
 If you need to differentiate between different magnetization transfer (MT) sequences, use the [`flip-<index>_mt-<on|off>`](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data) tag. For example, `sub-001_flip-1_mt-on_MTS.nii.gz`, `sub-001_flip-1_mt-off_MTS.nii.gz` or `sub-001_flip-2_mt-off_MTS.nii.gz`.
 ```
-acq-MTon_MTS → flip-1_mt-on_MTS
-acq-MToff_MTS → flip-1_mt-off_MTS
-acq-T1w_MTS → flip-2_mt-off_MTS
-```
 
 ```{note}
  If you to combine several above mentioned tags, use camelCase. For example, `sub-001_acq-cspineSagittal_T1w.nii.gz`.


### PR DESCRIPTION
## Purpose

This PR intends to centralize the discussion about the derivatives/label conventions.

## Motivation

Currently, many projects use their own derivatives convention, usually described in README, for example:

- [ivadomed](https://github.com/ivadomed/ivadomed/wiki/repositories#derivatives)
- [spine-generic](https://spine-generic.readthedocs.io/data-acquisition.html#data-conversion-dicom-to-bids)
- [model_seg_sci](https://github.com/ivadomed/model_seg_sci#data)
- [ukbiobank-spinalcord-csa](https://github.com/sct-pipeline/ukbiobank-spinalcord-csa#data-collection-and-organization)
- [fmri-segmentation](https://github.com/sct-pipeline/fmri-segmentation/issues/1)

## Description

This PR proposes the usage of `_label-<region>_<task>.nii.gz` tag, for example:
- `_label-SC_seg.nii.gz` - SC binary segmentation
- `_label-GM_seg.nii.gz` - GM binary segmentation
- `_label-SC_mask.nii.gz` - binary mask with diameter of XXmm centered at the center of the SC
- ...

For "tasks" such as `centerline`, `disc`, or `pmj`, the region is omitted; for example:
- `_label-centerline.nii.gz` - binary SC centerline
- `_label-disc.nii.gz` - voxels located at the posterior tip of each intervertebral disc
- `label-pmj.nii.gz` - single voxel with value of `50` corresponding to the pontomedullary junction (PMJ)
- ...

The full description is provided within this PR [here](https://github.com/neuropoly/intranet.neuro.polymtl.ca/blob/jv/centralize_derivatives_convection/data/dataset-curation.md#derivatives-structure).

Also, this PR proposes the usage of `derivatives/manual_labels` (instead of `derivatives/labels`). Thanks to that, we can omit `-manual` from the filename of each file (i.e., `sub-001_T1w_label-SC_seg-manual.nii.gz` --> `sub-001_T1w_label-SC_seg.nii.gz`). 

## Pros

- BIDS compatibility

## Cons

- incompatibility with our functions
	- `sct_deepseg_sc` and `sct_propseg` use [`_seg.nii.gz` suffix](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/a3d052b3cffff5058edf389e7f1600404c444e80/spinalcordtoolbox/scripts/sct_deepseg_sc.py#L94)
	- `sct_deepseg_gm` uses [`_gm_seg.nii.gz` suffix](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/a3d052b3cffff5058edf389e7f1600404c444e80/spinalcordtoolbox/scripts/sct_deepseg_gm.py#L44)
	- `ivadomed` uses ["target_suffix": ["_seg-manual", "_lesion-manual"]](https://ivadomed.org/configuration_file.html#target-suffix)
	- ...
- incompatibility with almost all git-annex datasets

## Previous discussions

- [`derivatives/labels` vs `derivatives/manual_labels`](https://github.com/neuropoly/data-management/issues/195#issuecomment-1369202235)
- [`derivatives/labels` vs `derivatives/label`](https://github.com/sct-pipeline/fmri-segmentation/issues/1#issuecomment-1366820882)
- [`label-SC`](https://github.com/neuropoly/data-management/issues/195#issuecomment-1368549703)
- also see Marie-Helene's [comment](https://github.com/neuropoly/intranet.neuro.polymtl.ca/pull/94#issuecomment-1403902603) below


## Useful links

- https://hackmd.io/@effigies/bids-derivatives-readme#Future-Directions
- https://docs.google.com/document/d/1YG2g4UkEio4t_STIBOqYOwneLEs1emHIXbGKynx7V0Y/edit#heading=h.mqkmyp254xh6

## TODO

- [ ] describe [fMRI](https://github.com/sct-pipeline/fmri-segmentation/issues/1#issuecomment-1366287008)
- [ ] describe [DWI](https://spine-generic.readthedocs.io/data-acquisition.html#data-conversion-dicom-to-bids)
- [ ] update [ivadomed/wiki/](https://github.com/ivadomed/ivadomed/wiki/repositories#derivatives) - crossref to intranet
- [ ] update [ivadomed.org](https://ivadomed.org/configuration_file.html#model-name)

## Questions

- `_label-SC_seg.nii.gz` vs `_label-SC_dseg.nii.gz` - [BIDS suggests `_dseg.nii.gz`](https://bids-specification.readthedocs.io/en/stable/glossary.html#dseg-suffixes) suffix for discrete segmentation instead `_seg.nii.gz`. However, `_seg.nii.gz` also seems to pass the `bids-validator`.
- `_label-centerline.nii.gz` vs `_label-SC-centerline.nii.gz` - should we omit or include the region for "tasks" where it is obvious that they are related to the spinal cord (SC)
- `derivatives/labels` vs `derivatives/label` - [this comment](https://github.com/sct-pipeline/fmri-segmentation/issues/1#issuecomment-1366820882) suggest singular (`label`), but so far, we have been using plural (`labels`).
- `derivatives/manual_labels/.../sub-XXX_T1w_label-SC_seg.nii.gz` vs `derivatives/labels/.../sub-XXX_T1w_label-SC_seg-manual.nii.gz` - if we use `manual_labels` instead of  `labels`, we can omit `manual` from filenames