### PR TITLE
Add `git annex init` to the `Cloning a repo` section

### DIFF
--- a/data/git-datasets.md
+++ b/data/git-datasets.md
@@ -108,6 +108,7 @@ If you want to run `git` commands from the command-line (`clone`, `pull`, `push`
    ```sh
    git clone git@data.neuro.polymtl.ca:datasets/"$REPO"
    cd "$REPO"
+   git annex init
    git annex dead here
    git annex get
    ```


### PR DESCRIPTION
Before running `git annex dead here`, I had to run `git annex init`


<img width="635" alt="image" src="https://github.com/neuropoly/intranet.neuro.polymtl.ca/assets/39456460/d9b543f6-d76a-4df3-865e-b10387dbfb16">
