### PR TITLE
Removing ControlPersist suggestion

### DIFF
--- a/computing-resources/neuropoly/README.md
+++ b/computing-resources/neuropoly/README.md
@@ -196,7 +196,6 @@ cat >>~/.ssh/config <<EOF
 Host *
 ControlMaster auto
 ControlPath ~/.ssh/%r@%h:%p
-ControlPersist 3s
 ```
 
 


### PR DESCRIPTION
Closes https://github.com/neuropoly/computers/issues/802

Again I don't know enough about ssh internals to know why this fails under non-interactive mode, but without it it defaults to 0s keepalive, which shouldn't be an issue.