### PR TITLE
Document conda environment inside set_slot

### DIFF
--- a/computing-resources/neuropoly/gpus.md
+++ b/computing-resources/neuropoly/gpus.md
@@ -1054,7 +1054,7 @@ for example a venv, use `set_slot` to start a shell (e.g. `set_slot 0 bash`) and
 (NB: the shell will not persist unless you run it in tmux or screen). We are still improving our
 script, so this may become possible in the future.
 
-- **If you need conda inside set_slot**, run `bash` with the `--login` or `-l` flag, e.g., `set_slot 1-2 bash -l`.
+- **If you need `conda` inside `set_slot`**, run `bash` with the `--login` or `-l` flag, e.g., `set_slot 1-2 bash -l`.
 This will put the proper folder inside the `PATH` environment variable.
 
 - **If you need to access duke inside `set_slot`**, run `set_slot` inside a shell (e.g., `set_slot 0 bash`), then

--- a/computing-resources/neuropoly/gpus.md
+++ b/computing-resources/neuropoly/gpus.md
@@ -1044,7 +1044,7 @@ set_slot <slot_number> <command> [args...]
 For example:
 ```
 set_slot 2 CUDA_VISIBLE_DEVICES=2 python3 myscript.py
-set_slot 0-3 bash
+set_slot 0-3 bash --login
 ```
 
 #### Special considerations
@@ -1053,6 +1053,9 @@ set_slot 0-3 bash
 for example a venv, use `set_slot` to start a shell (e.g. `set_slot 0 bash`) and then work in that shell.
 (NB: the shell will not persist unless you run it in tmux or screen). We are still improving our
 script, so this may become possible in the future.
+
+- **If you need conda inside set_slot**, run `bash` with the `--login` or `-l` flag, e.g., `set_slot 1-2 bash -l`.
+This will put the proper folder inside the `PATH` environment variable.
 
 - **If you need to access duke inside `set_slot`**, run `set_slot` inside a shell (e.g., `set_slot 0 bash`), then
   run `cifscreds add duke.neuro.polymtl.ca` in that shell. This will ensure that duke is still


### PR DESCRIPTION
`/etc/profile` isn't sourced inside `set_slot`, which is how miniforge injects conda into `PATH`. Passing `--login` to bash creates a full login shell, including sourcing `/etc/profile`